### PR TITLE
Updated gitflow to the up-to-date petervanderdoes version

### DIFF
--- a/vars.yml.dist
+++ b/vars.yml.dist
@@ -13,7 +13,7 @@ homebrew_apps:
     - brew-cask
     - htop-osx
     - ssh-copy-id
-    - git-flow
+    - git-flow-avh
     - heroku
     - docker
     - docker-compose


### PR DESCRIPTION
This change replaces the nvie/gitflow version with petervanderdoes/gitflow-avh, the previous hasn't been updated/maintained in years.
